### PR TITLE
Add group id feature

### DIFF
--- a/libby/daemon.py
+++ b/libby/daemon.py
@@ -167,6 +167,7 @@ class LibbyDaemon:
                 discover=self.config_discovery_enabled(),
                 discover_interval_s=self.config_discovery_interval_s(),
                 hello_on_start=True,
+                group_id=self.config_group_id(),
             )
 
     def serve(self) -> None:

--- a/libby/daemon.py
+++ b/libby/daemon.py
@@ -47,6 +47,7 @@ class LibbyDaemon:
     # transport selection: "zmq" (default) or "rabbitmq"
     transport: str = "zmq"
     rabbitmq_url: Optional[str] = None
+    group_id: Optional[str] = None
     # internal config
     _config: Dict[str, Any] = {}
 
@@ -100,6 +101,7 @@ class LibbyDaemon:
     def config_peer_id(self) -> str: return self.peer_id or self._must("peer_id")
     def config_bind(self) -> str: return self.bind or self._must("bind")
     def config_rabbitmq_url(self) -> str: return self.rabbitmq_url or "amqp://localhost"
+    def config_group_id(self) -> Optional[str]: return self.group_id
     def config_address_book(self) -> Dict[str, str]: return self.address_book if self.address_book is not None else {}
     def config_discovery_enabled(self) -> bool: return bool(self.discovery_enabled)
     def config_discovery_interval_s(self) -> float: return float(self.discovery_interval_s)
@@ -153,6 +155,7 @@ class LibbyDaemon:
                 rabbitmq_url=self.config_rabbitmq_url(),
                 keys=[],
                 callback=None,
+                group_id=self.config_group_id(),
             )
         else:
             # Default to ZMQ

--- a/libby/how_to_create_a_daemon.md
+++ b/libby/how_to_create_a_daemon.md
@@ -94,6 +94,7 @@ class MyPeer(LibbyDaemon):
     # RabbitMQ config
     transport = "rabbitmq"
     rabbitmq_url = "amqp://localhost"  # or "amqp://user:pass@host:5672/"
+    group_id = "workers"  # optional
 
     # No bind or address_book needed - broker handles routing!
 
@@ -287,6 +288,20 @@ Libby supports two transports that you can switch between with a single line:
 - **Setup**: Install and start RabbitMQ server
 
 **To switch transports**: Just change `transport = "zmq"` to `transport = "rabbitmq"` in your peer class. Everything else stays the same!
+
+### Group ID (optional)
+
+Optional `group_id` for grouping peers:
+
+```python
+class MyPeer(LibbyDaemon):
+    peer_id = "worker-1"
+    transport = "zmq"  # or "rabbitmq"
+    group_id = "workers"    # group this peer belongs to
+```
+
+- **RabbitMQ**: The group ID is included in the queue name (e.g., `libby.group.workers.peer.worker-1`) and enables group-aware features.
+- **ZMQ**: The group ID is stored as metadata and can be used for group-aware routing functions (turn on all devices in a group).
 
 ---
 

--- a/libby/libby.py
+++ b/libby/libby.py
@@ -54,6 +54,7 @@ class Libby:
         discover: bool = False,
         discover_interval_s: float = 5.0,
         hello_on_start: bool = True,
+        group_id: Optional[str] = None,
     ) -> "Libby":
         try:
             from .zmq_transport import ZmqTransport
@@ -64,7 +65,7 @@ class Libby:
                 "or provide your own Transport implementation."
             ) from e
 
-        t = ZmqTransport(bind_router=bind, address_book=address_book, my_id=self_id)
+        t = ZmqTransport(bind_router=bind, address_book=address_book, my_id=self_id, group_id=group_id)
         t.start()
         return cls(
             self_id=self_id,
@@ -93,7 +94,7 @@ class Libby:
             rabbitmq_url: RabbitMQ connection URL (default: "amqp://localhost")
             keys: List of RPC keys this peer will serve
             callback: Default callback for RPC requests
-            group_id: Optional group identifier for the queue name
+            group_id: Optional group identifier
 
         Returns:
             Configured Libby instance

--- a/libby/libby.py
+++ b/libby/libby.py
@@ -83,6 +83,7 @@ class Libby:
         rabbitmq_url: str = "amqp://localhost",
         keys: Optional[List[str]] = None,
         callback: Optional[Callable[[dict, dict], Optional[dict]]] = None,
+        group_id: Optional[str] = None,
     ) -> "Libby":
         """
         Create a Libby instance using RabbitMQ transport.
@@ -92,6 +93,7 @@ class Libby:
             rabbitmq_url: RabbitMQ connection URL (default: "amqp://localhost")
             keys: List of RPC keys this peer will serve
             callback: Default callback for RPC requests
+            group_id: Optional group identifier for the queue name
 
         Returns:
             Configured Libby instance
@@ -100,7 +102,8 @@ class Libby:
             >>> libby = Libby.rabbitmq(
             ...     self_id="peer-A",
             ...     rabbitmq_url="amqp://user:pass@localhost:5672/",
-            ...     keys=["echo"]
+            ...     keys=["echo"],
+            ...     group_id="hsfei"
             ... )
         """
         try:
@@ -113,7 +116,7 @@ class Libby:
                 "  pip install pika"
             ) from e
 
-        t = RabbitMQTransport(peer_id=self_id, rabbitmq_url=rabbitmq_url)
+        t = RabbitMQTransport(peer_id=self_id, rabbitmq_url=rabbitmq_url, group_id=group_id)
         t.start()
         return cls(
             self_id=self_id,

--- a/libby/rabbitmq_transport.py
+++ b/libby/rabbitmq_transport.py
@@ -108,6 +108,10 @@ class RabbitMQTransport:
         )
 
     @property
+    def group_id(self) -> Optional[str]:
+        return self._group_id
+
+    @property
     def mtu(self) -> int:
         """Maximum transmission unit - RabbitMQ can handle large messages."""
         return 512 * 1024

--- a/libby/rabbitmq_transport.py
+++ b/libby/rabbitmq_transport.py
@@ -20,16 +20,20 @@ class RabbitMQTransport:
     No address book needed - RabbitMQ broker handles all routing.
     """
 
-    def __init__(self, peer_id: str, rabbitmq_url: str = "amqp://localhost"):
+    def __init__(self, peer_id: str, rabbitmq_url: str = "amqp://localhost", group_id: Optional[str] = None):
         """
         Initialize RabbitMQ transport.
 
         Args:
             peer_id: Unique identifier for this peer
             rabbitmq_url: RabbitMQ connection URL (e.g., "amqp://user:pass@host:5672/")
+            group_id: Optional group identifier. If provided, included in queue name
+                      for future group functionality.
         """
         self._peer_id = peer_id
         self._url = rabbitmq_url
+        self._group_id = group_id
+        self._queue_name = self._build_queue_name()
         self._cb: Optional[Callable[[SrcStr, bytes], None]] = None
 
         # Send connection (used in main thread)
@@ -59,6 +63,12 @@ class RabbitMQTransport:
         except AMQPError as e:
             raise RuntimeError(f"Failed to setup RabbitMQ transport: {e}")
 
+    def _build_queue_name(self) -> str:
+        """Build queue name, including group_id if provided."""
+        if self._group_id:
+            return f"libby.group.{self._group_id}.peer.{self._peer_id}"
+        return f"libby.peer.{self._peer_id}"
+
     def _setup_topology(self, channel) -> None:
         """
         Declare exchanges, queue, and bindings on a given channel.
@@ -78,23 +88,22 @@ class RabbitMQTransport:
         )
 
         # Create this peer's queue
-        queue_name = f"libby.peer.{self._peer_id}"
         channel.queue_declare(
-            queue=queue_name,
+            queue=self._queue_name,
             durable=False,
             auto_delete=True
         )
 
         # Bind queue to direct exchange with peer_id as routing key
         channel.queue_bind(
-            queue=queue_name,
+            queue=self._queue_name,
             exchange='libby.direct',
             routing_key=self._peer_id
         )
 
         # Bind queue to fanout exchange (for broadcasts)
         channel.queue_bind(
-            queue=queue_name,
+            queue=self._queue_name,
             exchange='libby.fanout'
         )
 
@@ -191,7 +200,6 @@ class RabbitMQTransport:
         """Message receive loop - runs in background thread with its own connection."""
         recv_conn = None
         recv_ch = None
-        queue_name = f"libby.peer.{self._peer_id}"
 
         def message_callback(ch, method, properties, body):
             """Handle incoming message."""
@@ -223,7 +231,7 @@ class RabbitMQTransport:
 
             # Start consuming
             recv_ch.basic_consume(
-                queue=queue_name,
+                queue=self._queue_name,
                 on_message_callback=message_callback,
                 auto_ack=False  # Manual ack for reliability
             )
@@ -250,7 +258,7 @@ class RabbitMQTransport:
                         self._setup_topology(recv_ch)
 
                         recv_ch.basic_consume(
-                            queue=queue_name,
+                            queue=self._queue_name,
                             on_message_callback=message_callback,
                             auto_ack=False
                         )

--- a/libby/zmq_transport.py
+++ b/libby/zmq_transport.py
@@ -18,7 +18,7 @@ class ZmqTransport(Transport):
       We pass IDENT as "peer:<peer_id>" to the Protocol callback.
     """
 
-    def __init__(self, bind_router: str, address_book: Dict[str, str], my_id: str):
+    def __init__(self, bind_router: str, address_book: Dict[str, str], my_id: str, group_id: Optional[str] = None):
         self._ctx = zmq.Context.instance()
 
         self._router = self._ctx.socket(zmq.ROUTER)
@@ -36,6 +36,11 @@ class ZmqTransport(Transport):
         self._send_lock = threading.Lock()
 
         self._id = my_id  # local peer id
+        self._group_id = group_id
+
+    @property
+    def group_id(self) -> Optional[str]:
+        return self._group_id
 
     @property
     def mtu(self) -> int:

--- a/peers/peer_group.py
+++ b/peers/peer_group.py
@@ -1,0 +1,29 @@
+"""
+Test peer with group_id.
+"""
+import time
+from typing import Dict, Any
+from libby.daemon import LibbyDaemon
+
+
+def handle_echo(p: Dict[str, Any]):
+    return {"ok": True, "echo": p, "t": time.time()}
+
+
+class GroupTestPeer(LibbyDaemon):
+    peer_id = "group-test-peer"
+    transport = "rabbitmq"
+    rabbitmq_url = "amqp://localhost"
+    group_id = "hsfei"
+
+    services = {
+        "echo": handle_echo,
+    }
+
+    def on_start(self, libby):
+        print(f"[GroupTestPeer] Started with group_id='{self.group_id}'")
+        print(f"[GroupTestPeer] Expected queue name: libby.group.{self.group_id}.peer.{self.peer_id}")
+
+
+if __name__ == "__main__":
+    GroupTestPeer().serve()


### PR DESCRIPTION
- add group id feature in rabbitmq and zmq modes
  - example queue name for hsfei pickoff mirror: libby.group.hsfei.peer.pickoff
  - zmq peer will have group id as meta data
- add example peer with group id
- update how_to_create_a_daemon.md