### PR TITLE
Simple Implementation of loading sections into daemon using libby config injestion

### DIFF
--- a/libby/daemon.py
+++ b/libby/daemon.py
@@ -48,6 +48,7 @@ class LibbyDaemon:
     transport: str = "zmq"
     rabbitmq_url: Optional[str] = None
     group_id: Optional[str] = None
+    daemon_desc: Optional[str] = None
     # internal config
     _config: Dict[str, Any] = {}
 
@@ -106,6 +107,8 @@ class LibbyDaemon:
             d.rabbitmq_url = str(cfg["rabbitmq_url"])
         if "group_id" in cfg:
             d.group_id = str(cfg["group_id"])
+        if "daemon_desc" in cfg:
+            d.daemon_desc = str(cfg["daemon_desc"])
 
         return d
 

--- a/libby/daemon.py
+++ b/libby/daemon.py
@@ -51,6 +51,10 @@ class LibbyDaemon:
     # internal config
     _config: Dict[str, Any] = {}
 
+    # optional communication details to hardware
+    host: Optional[str] = None
+    port: Optional[int] = None
+
     # payload-only handlers
     services: Dict[str, RPCHandler] = {}
     topics: Dict[str, EvtHandler] = {}
@@ -82,13 +86,40 @@ class LibbyDaemon:
         d._config = dict(cfg)
 
         # map expected fields if provided
-        if "peer_id" in cfg: d.peer_id = cfg["peer_id"]
-        if "bind" in cfg: d.bind = cfg["bind"]
-        if "address_book" in cfg: d.address_book = cfg["address_book"]
-        if "discovery_enabled" in cfg: d.discovery_enabled = bool(cfg["discovery_enabled"])
-        if "discovery_interval_s" in cfg: d.discovery_interval_s = float(cfg["discovery_interval_s"])
+        if "peer_id" in cfg:
+            d.peer_id = cfg["peer_id"]
+        if "bind" in cfg:
+            d.bind = cfg["bind"]
+        if "address_book" in cfg:
+            d.address_book = cfg["address_book"]
+        if "discovery_enabled" in cfg:
+            d.discovery_enabled = bool(cfg["discovery_enabled"])
+        if "discovery_interval_s" in cfg:
+            d.discovery_interval_s = float(cfg["discovery_interval_s"])
+        if "host" in cfg:
+            d.host = cfg["host"]
+        if "port" in cfg:
+            d.port = int(cfg["port"])
+        if "transport" in cfg:
+            d.transport = str(cfg["transport"])
+        if "rabbitmq_url" in cfg:
+            d.rabbitmq_url = str(cfg["rabbitmq_url"])
+        if "group_id" in cfg:
+            d.group_id = str(cfg["group_id"])
 
         return d
+
+    @classmethod
+    def load_config_section(cls, path: str, section: str, *, env_prefix: str = "LIBBY_") -> "LibbyDaemon":
+        """
+        Build a dict from a config file and extract a specific section for the daemon.
+        """
+        cfg = with_env_overrides(load_config(path), prefix=env_prefix)
+        if section not in cfg or not isinstance(cfg[section], dict):
+            raise ValueError(f"Config section '{section}' missing or not a dict in {path}")
+        if "communication" in section:
+            return cls.from_config(cfg[section])
+        return cfg[section]
 
     # optional hooks
     def on_start(self, libby: Libby) -> None: ...


### PR DESCRIPTION
This is a better implementation of the libby config section injestion I submitted earlier. with this we could load all of our daemon parameters from the config file in the libby class and also handle sections for things like named_pos or limits. this assumes a json or yaml file. this only builds on the idea that we are still doing one config file per group/subsystem and trying to avoid having a config for every daemon.
YAML FILE EXAMPLE:
atcfwheel-communication:
  host: "192.168.29.100"
  port: 10010
  peer_id: atcfwheel
  group_id: hsfei
  bind: null
  address_book: null
  transport = "rabbitmq"
  discovery_enabled = False
  discovery_interval_s = 5.0
  rabbitmq_url = "amqp://localhost"
  daemon_desc = "ATC FWheel"

atcfwheel-named_pos:
  clear: 1
  nd2: 2
  nd3: 3
  nd4: 4
  nd5: 5
  nd6: 6
